### PR TITLE
feat: track link clicks

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -185,6 +185,7 @@
                             <th>Public?</th>
                             <th>Created At</th>
                             <th>Expires At</th>
+                            <th>Clicks</th>
                             <th>Delete</th>
                         </tr>
                     </thead>
@@ -475,6 +476,7 @@
             <td>${link.passwordProtected ? "Private" : "Public"}</td>
             <td>${created}</td>
             <td>${expires}</td>
+            <td>${link.clicks || 0}</td>
             <td>
               <button class="btn delete" data-slug="${link.slug}">
                 🗑️

--- a/src/index.js
+++ b/src/index.js
@@ -178,6 +178,7 @@ export default {
       const key = slug || generateSlug();
       const data = {
         url: targetUrl,
+        clicks: 0,
         metadata: {
           createdAtUtc: now,
           formattedCreated,
@@ -251,6 +252,7 @@ export default {
           const item = {
             slug: name,
             url: data.url,
+            clicks: data.clicks || 0,
             passwordProtected: !!data.metadata.passwordProtected,
             metadata: {
               createdAt: data.metadata.formattedCreated,
@@ -333,7 +335,9 @@ export default {
           }
         }
 
-        // public or (correctly unlocked) → redirect
+        // public or (correctly unlocked) → increment clicks then redirect
+        data.clicks = (data.clicks || 0) + 1;
+        await KV.put(slug, JSON.stringify(data));
         return Response.redirect(data.url, 302);
       }
     }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,18 +1,46 @@
-import { env, createExecutionContext, waitOnExecutionContext, SELF } from 'cloudflare:test';
-import { describe, it, expect } from 'vitest';
-import worker from '../src';
+import {
+  env,
+  createExecutionContext,
+  waitOnExecutionContext,
+  SELF,
+} from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+import worker from "../src";
 
-describe('Hello World worker', () => {
-	it('responds with Hello World! (unit style)', async () => {
-		const request = new Request('http://example.com');
-		const ctx = createExecutionContext();
-		const response = await worker.fetch(request, env, ctx);
-		await waitOnExecutionContext(ctx);
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
-	});
+describe("URL shortener worker", () => {
+  it("serves index page at root", async () => {
+    const response = await SELF.fetch("http://example.com/");
+    const text = await response.text();
+    expect(text).toContain("<!doctype html>");
+  });
 
-	it('responds with Hello World! (integration style)', async () => {
-		const response = await SELF.fetch('http://example.com');
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
-	});
+  it("increments click count on redirect", async () => {
+    const slug = "abc123";
+    const now = Date.now();
+    await env.URLS.put(
+      slug,
+      JSON.stringify({
+        url: "https://example.com",
+        clicks: 0,
+        metadata: {
+          createdAtUtc: now,
+          formattedCreated: "",
+          expiresAtUtc: null,
+          formattedExpiration: "Never",
+          passwordProtected: false,
+        },
+      })
+    );
+
+    const request = new Request(`http://example.com/${slug}`);
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(request, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(response.status).toBe(302);
+
+    const stored = await env.URLS.get(slug);
+    const data = JSON.parse(stored);
+    expect(data.clicks).toBe(1);
+  });
 });
+


### PR DESCRIPTION
## Summary
- track click counts for shortened links and increment on redirect
- expose click data via API and UI
- add tests for redirect click tracking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68995a174230832fae354040a2a7d504