### PR TITLE
feat: allow super admin to view link passwords

### DIFF
--- a/src/api-docs.md
+++ b/src/api-docs.md
@@ -1,7 +1,7 @@
 
 # Link Shortener API Documentation
 
-A serverless link shortener API with expiration, password protection, and authentication, powered by Workers KV.
+A serverless link shortener API with expiration, password protection, and authentication, powered by Workers KV. Passwords may be viewed only by super users who provide the correct admin secret.
 
 ## 🌐 Base URL
 
@@ -56,23 +56,27 @@ Shorten a new URL.
 }
 ```
 
+Passwords can be viewed only when the `X-Super-Secret` header matches the super admin key.
+
 ---
 
 ### `GET /api/links`
 
-List **all** valid (non-expired) shortened URLs—public and password-protected alike.
+List **all** valid (non-expired) shortened URLs.
 
 **Headers:**
 
 - `Authorization: Bearer <API_KEY>`
+- `X-Super-Secret: <ADMIN_KEY>` – Optional; include to also return private links and their passwords.
 
-**Response:**
+**Response (with super secret):**
 
 ```json
 [
   {
     "slug": "exmpl",
     "url": "https://example.com",
+    "password": null,
     "metadata": {
       "createdAt": "July 30, 2025, 09:00 AM CDT",
       "expirationInSeconds": 3600,
@@ -83,6 +87,7 @@ List **all** valid (non-expired) shortened URLs—public and password-protected 
   {
     "slug": "privatelink",
     "url": "https://private.example.com",
+    "password": "secret",
     "metadata": {
       "createdAt": "July 30, 2025, 08:00 AM CDT",
       "expirationInSeconds": 7200,

--- a/src/api-docs.txt
+++ b/src/api-docs.txt
@@ -1,7 +1,7 @@
 
 # Link Shortener API Documentation
 
-A serverless link shortener API with expiration, password protection, and authentication, powered by Workers KV.
+A serverless link shortener API with expiration, password protection, and authentication, powered by Workers KV. Passwords may be viewed only by super users who provide the correct admin secret.
 
 ## 🌐 Base URL
 
@@ -56,23 +56,27 @@ Shorten a new URL.
 }
 ```
 
+Passwords can be viewed only when the `X-Super-Secret` header matches the super admin key.
+
 ---
 
 ### `GET /api/links`
 
-List **all** valid (non-expired) shortened URLs—public and password-protected alike.
+List **all** valid (non-expired) shortened URLs.
 
 **Headers:**
 
 - `Authorization: Bearer <API_KEY>`
+- `X-Super-Secret: <ADMIN_KEY>` – Optional; include to also return private links and their passwords.
 
-**Response:**
+**Response (with super secret):**
 
 ```json
 [
   {
     "slug": "exmpl",
     "url": "https://example.com",
+    "password": null,
     "metadata": {
       "createdAt": "July 30, 2025, 09:00 AM CDT",
       "expirationInSeconds": 3600,
@@ -83,6 +87,7 @@ List **all** valid (non-expired) shortened URLs—public and password-protected 
   {
     "slug": "privatelink",
     "url": "https://private.example.com",
+    "password": "secret",
     "metadata": {
       "createdAt": "July 30, 2025, 08:00 AM CDT",
       "expirationInSeconds": 7200,

--- a/src/index.html
+++ b/src/index.html
@@ -183,6 +183,7 @@
                             <th>Redirect URL</th>
                             <th>Destination URL</th>
                             <th>Public?</th>
+                            <th>Password</th>
                             <th>Created At</th>
                             <th>Expires At</th>
                             <th>Clicks</th>
@@ -301,9 +302,6 @@
            `;
                                 if (item.passwordProtected) {
                                     line += " 🔒";
-                                    if (item.password) {
-                                        line += ` (password: ${item.password})`;
-                                    }
                                 }
                                 line += "</li>";
                                 $("#links-list").append(line);
@@ -474,6 +472,7 @@
             <td><a href="${redirectUrl}" target="_blank">${redirectUrl}</a></td>
             <td><a href="${link.url}" target="_blank">${link.url}</a></td>
             <td>${link.passwordProtected ? "Private" : "Public"}</td>
+            <td>${link.password || ""}</td>
             <td>${created}</td>
             <td>${expires}</td>
             <td>${link.clicks || 0}</td>

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -7,6 +7,16 @@ import {
 import { describe, it, expect } from "vitest";
 import worker from "../src";
 
+const hash = async (str) => {
+  const buf = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(str),
+  );
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+};
+
 describe("URL shortener worker", () => {
   it("serves index page at root", async () => {
     const response = await SELF.fetch("http://example.com/");
@@ -41,6 +51,100 @@ describe("URL shortener worker", () => {
     const stored = await env.URLS.get(slug);
     const data = JSON.parse(stored);
     expect(data.clicks).toBe(1);
+  });
+
+  it("serves a password form and validates passwords", async () => {
+    const slug = "secure";
+    const now = Date.now();
+    const passwordHash = await hash("secret");
+    await env.URLS.put(
+      slug,
+      JSON.stringify({
+        url: "https://example.com",
+        clicks: 0,
+        passwordHash,
+        metadata: {
+          createdAtUtc: now,
+          formattedCreated: "",
+          expiresAtUtc: null,
+          formattedExpiration: "Never",
+          passwordProtected: true,
+        },
+      }),
+    );
+
+    // GET should return HTML form
+    let req = new Request(`http://example.com/${slug}`);
+    let ctx = createExecutionContext();
+    let resp = await worker.fetch(req, env, ctx);
+    await waitOnExecutionContext(ctx);
+    const body = await resp.text();
+    expect(resp.status).toBe(200);
+    expect(body).toContain("Enter password");
+
+    // POST wrong password
+    req = new Request(`http://example.com/${slug}`, {
+      method: "POST",
+      body: new URLSearchParams({ password: "wrong" }),
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    });
+    ctx = createExecutionContext();
+    resp = await worker.fetch(req, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(resp.status).toBe(401);
+
+    // POST correct password
+    req = new Request(`http://example.com/${slug}`, {
+      method: "POST",
+      body: new URLSearchParams({ password: "secret" }),
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    });
+    ctx = createExecutionContext();
+    resp = await worker.fetch(req, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(resp.status).toBe(302);
+
+    const stored = await env.URLS.get(slug);
+    const data = JSON.parse(stored);
+    expect(data.clicks).toBe(1);
+  });
+
+  it("allows super user to view private link passwords", async () => {
+    const slug = "priv";
+    const now = Date.now();
+    const password = "secret";
+    const passwordHash = await hash(password);
+    await env.URLS.put(
+      slug,
+      JSON.stringify({
+        url: "https://example.com",
+        clicks: 0,
+        password,
+        passwordHash,
+        metadata: {
+          createdAtUtc: now,
+          formattedCreated: "",
+          expiresAtUtc: null,
+          formattedExpiration: "Never",
+          passwordProtected: true,
+        },
+      }),
+    );
+    await env.URLS.put("SUPER_SECRET_KEY", "topsecret");
+
+    const req = new Request("http://example.com/api/links", {
+      headers: {
+        Authorization: "Bearer key",
+        "X-Super-Secret": "topsecret",
+      },
+    });
+    const ctx = createExecutionContext();
+    const resp = await worker.fetch(req, env, ctx);
+    await waitOnExecutionContext(ctx);
+    const data = await resp.json();
+    expect(Array.isArray(data)).toBe(true);
+    const item = data.find((i) => i.slug === slug);
+    expect(item.password).toBe(password);
   });
 });
 


### PR DESCRIPTION
## Summary
- store plaintext passwords alongside hashes and reveal them to super admins via `/api/links`
- add password column to manage UI and label unlock form "Enter password"
- document super-admin header required to see private link passwords

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899e8a0ad80832fb11a90f1659c13b8